### PR TITLE
list.add_list_member() not passing `skip_merge_validation` to API

### DIFF
--- a/mailchimp_marketing/api_client.py
+++ b/mailchimp_marketing/api_client.py
@@ -132,7 +132,7 @@ class ApiClient(object):
         elif method == "OPTIONS":
             return requests.options(url, params=query_params, headers=headers, auth=auth)
         elif method == "POST":
-            return requests.post(url, data=json.dumps(body), headers=headers, auth=auth)
+            return requests.post(url, data=json.dumps(body), params=query_params, headers=headers, auth=auth)
         elif method == "PUT":
             return requests.put(url, data=json.dumps(body), headers=headers, auth=auth)
         elif method == "PATCH":


### PR DESCRIPTION
I was trying to call `list.add_list_member()` with the query parameter `skip_merge_validation`. However, the code did not send `skip_merge_validation` to the API. This is because the code was not sending query parameters with any POST requests. 

This fixed the issue for POST requests only.